### PR TITLE
feat: scaffolding command for generating a provider

### DIFF
--- a/cmd/scaffolding/provider/main.go
+++ b/cmd/scaffolding/provider/main.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"embed"
+	"flag"
+	"fmt"
+	"github.com/doejon/jonson"
+	"log"
+	"os"
+	"path/filepath"
+	"text/template"
+)
+
+//go:embed *.tmpl
+var tfs embed.FS
+
+func main() {
+
+	var providerName string
+	var providedType string
+	flag.StringVar(&providerName, "providerName", "test", "desired provider name")
+	flag.StringVar(&providedType, "providedType", "MyValue", "desired provided type")
+
+	flag.Parse()
+
+	if providerName == "" || providedType == "" {
+		flag.PrintDefaults()
+		os.Exit(1)
+	}
+
+	tmpl, err := template.ParseFS(tfs, "provider.go.tmpl")
+	if err != nil {
+		log.Fatalf("parsing template: %s", err)
+	}
+
+	dstPath := filepath.Join(dirname(), fmt.Sprintf("%s-provider.go", providerName))
+	if err := ensureNotOverwriting(dstPath); err != nil {
+		log.Fatalf("file %s already exists: %s", dstPath, err)
+	}
+
+	dst, err := os.Create(dstPath)
+	if err != nil {
+		log.Fatalf("create file %s: %w", dstPath, err)
+	}
+	defer dst.Close()
+
+	data := struct {
+		Name string
+		Type string
+	}{
+		Name: jonson.ToPascalCase(providerName),
+		Type: jonson.ToPascalCase(providedType),
+	}
+
+	if err := tmpl.ExecuteTemplate(dst, tmpl.Name(), data); err != nil {
+		log.Fatalf("executing template for %s: %s", dst.Name(), err)
+	}
+}
+
+func ensureNotOverwriting(filename string) error {
+	_, err := os.Stat(filename)
+	if err == nil {
+		return fmt.Errorf("file already exists: %s", filename)
+	}
+	if !os.IsNotExist(err) {
+		return fmt.Errorf("stat file: %s, %w", filename, err)
+	}
+	return nil
+}
+
+func dirname() string {
+	getwd, err := os.Getwd()
+	if err != nil {
+		log.Fatal("getting current directory")
+	}
+
+	return getwd
+}

--- a/cmd/scaffolding/provider/provider.go.tmpl
+++ b/cmd/scaffolding/provider/provider.go.tmpl
@@ -1,0 +1,22 @@
+package main
+
+import "github.com/doejon/jonson"
+
+//go:generate go run gitlab.dto.rocks/dto/dtpa/go/jonson/cmd/generate
+
+// @generate
+type {{.Type}} struct {
+}
+
+type {{.Name}}Provider struct {
+}
+
+func New{{.Name}}Provider() *{{.Name}}Provider {
+    // TODO implement me
+	return &{{.Name}}Provider{}
+}
+
+func (p *{{.Name}}Provider) New{{.Type}}(ctx *jonson.Context) *{{.Type}} {
+    // TODO implement me
+	return &{{.Type}}{}
+}


### PR DESCRIPTION
What do you think of some scaffolding commands? 
We could run them from projects with 
`go run ./cmd/scaffolding/provider/ -providerName=my-provider`