### PR TITLE
feat(core): introduce response mutator interface for "plugins" and a basic benchmark system

### DIFF
--- a/benchmark/system.go
+++ b/benchmark/system.go
@@ -1,0 +1,57 @@
+// Package benchmark provides minimal, exportable Jonson systems and payloads
+// for use in external benchmarks and integration tests.
+package benchmark
+
+import "github.com/doejon/jonson"
+
+// --- Test System for Benchmarking ---
+
+// System BenchmarkSystem is a mock Jonson system with a single method
+// designed to return a complex payload for performance testing.
+type System struct{}
+
+// NewBenchmarkSystem provides a pre-configured Jonson system for use in benchmarks.
+func NewBenchmarkSystem() *System {
+	return &System{}
+}
+
+// ComplexResponseV1Result defines the result structure for the benchmark method.
+type ComplexResponseV1Result struct {
+	Payload *Payload
+}
+
+// ComplexResponseV1 is the RPC method that returns a complex data structure.
+func (s *System) ComplexResponseV1(_ *jonson.Context) (*ComplexResponseV1Result, error) {
+	return &ComplexResponseV1Result{Payload: NewPayload()}, nil
+}
+
+// --- Test Payload for Benchmarking ---
+
+// Payload defines a complex data structure used for benchmarking normalization logic.
+type Payload struct {
+	ID          string
+	Users       []User
+	Permissions map[string][]string
+	Metadata    *Metadata
+}
+
+// User is a sub-structure for the benchmark payload.
+type User struct {
+	Name          string
+	Emails, Roles []string
+}
+
+// Metadata is a sub-structure for the benchmark payload.
+type Metadata struct {
+	Logs, ParentIDs []string
+}
+
+// NewPayload creates a fresh instance of the complex payload with several nil slices.
+func NewPayload() *Payload {
+	return &Payload{
+		ID:          "payload-123",
+		Users:       []User{{Name: "Alice", Roles: nil}, {Name: "Bob", Emails: nil}},
+		Permissions: map[string][]string{"admin": {"read", "write"}, "user": nil},
+		Metadata:    &Metadata{Logs: nil},
+	}
+}

--- a/internal/example/req.http
+++ b/internal/example/req.http
@@ -24,7 +24,7 @@ content-type: application/json
 {
 	"id": 1,
 	"version": "2.0",
-	"method": "account/get.v1",
+	"method": "account/me.v1",
 	"params": {
     	"uuid": "70634da0-7459-4a17-a50f-7afc2a600d50"
 	}
@@ -38,7 +38,7 @@ Authorization: authorized
 {
 	"id": 1,
 	"version": "2.0",
-	"method": "account/get.v1",
+	"method": "account/me.v1",
 	"params": {
     	"uuid": "70634da0-7459-4a17-a50f-7afc2a600d50"
 	}

--- a/jonsontest/jonsontest.go
+++ b/jonsontest/jonsontest.go
@@ -15,14 +15,14 @@ type TestContextBoundary struct {
 	opts          []NewTestContextBoundaryOpt
 	methodHandler *jonson.MethodHandler
 	factory       *jonson.Factory
-	t             *testing.T
+	t             testing.TB
 
 	stackInspector []func(s string)
 }
 
 // NewTestContext returns a new test context
 func NewContextBoundary(
-	t *testing.T,
+	t testing.TB,
 	factory *jonson.Factory,
 	methodHandler *jonson.MethodHandler,
 	opts ...NewTestContextBoundaryOpt) *TestContextBoundary {

--- a/method.handler.go
+++ b/method.handler.go
@@ -78,12 +78,25 @@ var validMissingValidationLevel = map[MissingValidationLevel]struct{}{
 	MissingValidationLevelFatal:  {},
 }
 
+// ResponseMutator defines an interface for components that can inspect and modify
+// a successful RPC response object before it gets marshaled to JSON.
+// This allows for creating external "plugins" for response processing.
+type ResponseMutator interface {
+	// Mutate is called for every successful response.
+	// The `result` argument is the actual data returned by the RPC method.
+	// Implementations of Mutate can modify the result in-place using reflection.
+	Mutate(result any, logger *slog.Logger)
+}
+
 type MethodHandlerOptions struct {
 	MissingValidationLevel MissingValidationLevel
 	// allows you to intercept the rpc log message before it reaches the final
 	// log; This allows you to e.g. hide parameters
 	RpcRequestLogInfoInterceptor func(info *RpcRequestLogInfo) *RpcRequestLogInfo
 	JsonHandler                  JsonHandler
+
+	// Hold response mutator plugins.
+	ResponseMutators []ResponseMutator
 }
 
 func GetDefaultMethodName(system string, method string, version uint64) string {

--- a/plugins/nil_slice_normalizer.go
+++ b/plugins/nil_slice_normalizer.go
@@ -1,0 +1,111 @@
+package plugins
+
+import (
+	"github.com/doejon/jonson"
+	"log/slog"
+	"reflect"
+)
+
+// LogLevel defines the logging verbosity for the normalizer.
+type LogLevel string
+
+const (
+	LogLevelNone  LogLevel = "none"
+	LogLevelDebug LogLevel = "debug"
+	LogLevelInfo  LogLevel = "info"
+	LogLevelWarn  LogLevel = "warn"
+)
+
+// Compile-time check to ensure *NilSliceNormalizer implements the jonson.ResponseMutator interface.
+var _ jonson.ResponseMutator = (*NilSliceNormalizer)(nil)
+
+type NilSliceNormalizer struct {
+	LogLevel LogLevel
+}
+
+func (n *NilSliceNormalizer) Mutate(result any, logger *slog.Logger) {
+	visited := make(map[uintptr]bool)
+	n.normalizeRecursive(reflect.ValueOf(result), visited, logger, "response")
+}
+
+// normalizeRecursive recursively traverses the value and normalizes nil slices to empty slices.
+func (n *NilSliceNormalizer) normalizeRecursive(val reflect.Value, visited map[uintptr]bool, logger *slog.Logger, path string) {
+	// If value is invalid (e.g. from a nil interface), stop.
+	if !val.IsValid() {
+		return
+	}
+
+	// First, handle pointers to traverse to the actual data.
+	if val.Kind() == reflect.Ptr {
+		if val.IsNil() {
+			return
+		}
+		ptrAddr := val.Pointer()
+		if visited[ptrAddr] {
+			return // Cycle detected.
+		}
+		visited[ptrAddr] = true
+		n.normalizeRecursive(val.Elem(), visited, logger, path)
+		return
+	}
+
+	// Now, switch on the concrete kind of the value.
+	switch val.Kind() {
+	case reflect.Struct:
+		for i := 0; i < val.NumField(); i++ {
+			// Recurse into each field of the struct.
+			newPath := path + "." + val.Type().Field(i).Name
+			n.normalizeRecursive(val.Field(i), visited, logger, newPath)
+		}
+
+	case reflect.Slice:
+		if val.IsNil() {
+			if val.CanSet() {
+				// Log with the configured level.
+				if n.LogLevel != LogLevelNone {
+					msg := "Found nil slice in response, normalizing to empty array `[]`"
+					attrs := slog.String("path", path)
+					switch n.LogLevel {
+					case LogLevelDebug:
+						logger.Debug(msg, attrs)
+					case LogLevelInfo:
+						logger.Info(msg, attrs)
+					case LogLevelWarn:
+						logger.Warn(msg, attrs)
+					default:
+						logger.Warn("Unknown LogLevel in NilSliceNormalizer, defaulting to Warn for notification", "configuredLevel", n.LogLevel)
+						logger.Warn(msg, attrs)
+					}
+				}
+				// Replace the nil slice with an empty one.
+				val.Set(reflect.MakeSlice(val.Type(), 0, 0))
+			}
+			return // Normalization done, no elements to inspect.
+		}
+		// If the slice is not nil, recurse into its elements.
+		for i := 0; i < val.Len(); i++ {
+			n.normalizeRecursive(val.Index(i), visited, logger, path+"[]")
+		}
+
+	case reflect.Map:
+		if val.IsNil() {
+			return
+		}
+		// Recurse into each value of the map. The user requested not to normalize
+		// nil maps to {}, but we still need to inspect their contents.
+		for _, key := range val.MapKeys() {
+			n.normalizeRecursive(val.MapIndex(key), visited, logger, path+"{}")
+		}
+
+	case reflect.Interface:
+		if val.IsNil() {
+			return
+		}
+		// Look inside the interface to find the concrete value and recurse.
+		n.normalizeRecursive(val.Elem(), visited, logger, path)
+
+	default:
+		// No action is needed, simply stop the recursion for this branch.
+		return
+	}
+}

--- a/plugins/nil_slice_normalizer_benchmark_test.go
+++ b/plugins/nil_slice_normalizer_benchmark_test.go
@@ -1,0 +1,79 @@
+package plugins
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/doejon/jonson"
+	"github.com/doejon/jonson/benchmark"
+)
+
+func BenchmarkMutateFunction(b *testing.B) {
+	plugin := &NilSliceNormalizer{LogLevel: LogLevelNone}
+	logger := slog.New(slog.NewJSONHandler(io.Discard, nil))
+
+	for i := 0; i < b.N; i++ {
+		payload := benchmark.NewPayload()
+		plugin.Mutate(payload, logger)
+	}
+}
+
+func BenchmarkEndToEnd_WithAndWithoutPlugin(b *testing.B) {
+	scenarios := []struct {
+		name   string
+		plugin jonson.ResponseMutator
+	}{
+		{
+			name:   "WithoutPlugin",
+			plugin: nil,
+		},
+		{
+			name:   "WithPlugin",
+			plugin: &NilSliceNormalizer{LogLevel: LogLevelNone},
+		},
+	}
+
+	for _, s := range scenarios {
+		b.Run(s.name, func(b *testing.B) {
+			factory := jonson.NewFactory()
+			secret := jonson.NewDebugSecret()
+			testSystem := benchmark.NewBenchmarkSystem()
+
+			var mutators []jonson.ResponseMutator
+			if s.plugin != nil {
+				mutators = append(mutators, s.plugin)
+			}
+
+			methodHandler := jonson.NewMethodHandler(factory, secret, &jonson.MethodHandlerOptions{
+				ResponseMutators: mutators,
+			})
+			methodHandler.RegisterSystem(testSystem)
+
+			jonsonServer := jonson.NewServer(jonson.NewHttpRpcHandler(methodHandler, "/rpc"))
+			server := httptest.NewServer(jonsonServer)
+			defer server.Close()
+
+			client := server.Client()
+			rpcReq, _ := json.Marshal(jonson.RpcRequest{
+				Version: "2.0",
+				ID:      []byte(`"1"`),
+				Method:  "benchmark-system/complex-response.v1",
+			})
+
+			b.ResetTimer()
+
+			for i := 0; i < b.N; i++ {
+				resp, err := client.Post(server.URL+"/rpc", "application/json", bytes.NewReader(rpcReq))
+				if err != nil {
+					b.Fatalf("Request failed: %v", err)
+				}
+				_, _ = io.Copy(io.Discard, resp.Body)
+				_ = resp.Body.Close()
+			}
+		})
+	}
+}

--- a/plugins/nil_slice_normalizer_test.go
+++ b/plugins/nil_slice_normalizer_test.go
@@ -1,0 +1,223 @@
+package plugins
+
+import (
+	"bytes"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type SimpleStruct struct {
+	Name string
+	Tags []string
+}
+
+type ComplexStruct struct {
+	ID      int
+	Profile *SimpleStruct
+	Data    []SimpleStruct
+}
+
+type UnexportedFieldStruct struct {
+	internalTags []string
+	PublicTags   []string
+}
+
+type CyclicStructA struct {
+	Name    string
+	Friends []string
+	B       *CyclicStructB
+}
+
+type CyclicStructB struct {
+	Name    string
+	Secrets []string
+	A       *CyclicStructA
+}
+
+func TestNilSliceNormalizer_Mutate(t *testing.T) {
+	testCases := []struct {
+		name             string
+		plugin           *NilSliceNormalizer
+		input            any
+		expected         any
+		logShouldContain string
+	}{
+		{
+			name:   "Simple struct with nil slice",
+			plugin: &NilSliceNormalizer{LogLevel: LogLevelWarn},
+			input:  &SimpleStruct{Name: "test1", Tags: nil},
+			expected: &SimpleStruct{
+				Name: "test1",
+				Tags: make([]string, 0),
+			},
+			logShouldContain: `"msg":"Found nil slice in response, normalizing to empty array ` + "`[]`" + `","path":"response.Tags"`,
+		},
+		{
+			name:   "Struct with already empty slice should not change",
+			plugin: &NilSliceNormalizer{LogLevel: LogLevelWarn},
+			input:  &SimpleStruct{Name: "test2", Tags: make([]string, 0)},
+			expected: &SimpleStruct{
+				Name: "test2",
+				Tags: make([]string, 0),
+			},
+			logShouldContain: "",
+		},
+		{
+			name:   "Struct with populated slice should not change",
+			plugin: &NilSliceNormalizer{LogLevel: LogLevelWarn},
+			input:  &SimpleStruct{Name: "test3", Tags: []string{"a", "b"}},
+			expected: &SimpleStruct{
+				Name: "test3",
+				Tags: []string{"a", "b"},
+			},
+			logShouldContain: "",
+		},
+		{
+			name:   "Nested struct with nil slice",
+			plugin: &NilSliceNormalizer{LogLevel: LogLevelWarn},
+			input: &ComplexStruct{
+				ID:      100,
+				Profile: &SimpleStruct{Name: "nested", Tags: nil},
+				Data:    nil,
+			},
+			expected: &ComplexStruct{
+				ID: 100,
+				Profile: &SimpleStruct{
+					Name: "nested",
+					Tags: make([]string, 0),
+				},
+				Data: make([]SimpleStruct, 0),
+			},
+			// We will get two log entries, so we check for the most specific one.
+			logShouldContain: `"path":"response.Profile.Tags"`,
+		},
+		{
+			name:   "Slice of structs with some nil slices",
+			plugin: &NilSliceNormalizer{LogLevel: LogLevelInfo},
+			input: &ComplexStruct{
+				Data: []SimpleStruct{
+					{Name: "data1", Tags: []string{"a"}},
+					{Name: "data2", Tags: nil},
+				},
+			},
+			expected: &ComplexStruct{
+				Data: []SimpleStruct{
+					{Name: "data1", Tags: []string{"a"}},
+					{Name: "data2", Tags: make([]string, 0)},
+				},
+			},
+			logShouldContain: `"path":"response.Data[].Tags"`,
+		},
+		{
+			name:   "Nil pointer in struct should be ignored but other fields normalized",
+			plugin: &NilSliceNormalizer{LogLevel: LogLevelWarn},
+			input: &ComplexStruct{
+				ID:      102,
+				Profile: nil,
+				Data:    nil,
+			},
+			expected: &ComplexStruct{
+				ID:      102,
+				Profile: nil,
+				Data:    make([]SimpleStruct, 0),
+			},
+			logShouldContain: `"path":"response.Data"`,
+		},
+		{
+			name:             "Logging disabled with LogLevelNone",
+			plugin:           &NilSliceNormalizer{LogLevel: LogLevelNone},
+			input:            &SimpleStruct{Name: "test-no-log", Tags: nil},
+			expected:         &SimpleStruct{Name: "test-no-log", Tags: make([]string, 0)},
+			logShouldContain: "",
+		},
+		{
+			name:             "Invalid LogLevel should produce a warning about the level",
+			plugin:           &NilSliceNormalizer{LogLevel: "invalid-level"},
+			input:            &SimpleStruct{Name: "test-invalid-log", Tags: nil},
+			expected:         &SimpleStruct{Name: "test-invalid-log", Tags: make([]string, 0)},
+			logShouldContain: "Unknown LogLevel in NilSliceNormalizer",
+		},
+		{
+			name:   "Unexported field should be ignored",
+			plugin: &NilSliceNormalizer{LogLevel: LogLevelWarn},
+			input: &UnexportedFieldStruct{
+				internalTags: nil,
+				PublicTags:   nil,
+			},
+			expected: &UnexportedFieldStruct{
+				internalTags: nil,
+				PublicTags:   make([]string, 0),
+			},
+			logShouldContain: `"path":"response.PublicTags"`,
+		},
+		{
+			name:             "Nil input should not panic",
+			plugin:           &NilSliceNormalizer{LogLevel: LogLevelWarn},
+			input:            nil,
+			expected:         nil,
+			logShouldContain: "",
+		},
+	}
+
+	// Add cyclic test case
+	cyclicNodeA := &CyclicStructA{Name: "A", Friends: nil}
+	cyclicNodeB := &CyclicStructB{Name: "B", Secrets: nil}
+	cyclicNodeA.B = cyclicNodeB
+	cyclicNodeB.A = cyclicNodeA
+	testCases = append(testCases, struct {
+		name             string
+		plugin           *NilSliceNormalizer
+		input            any
+		expected         any
+		logShouldContain string
+	}{
+		name:   "Cyclic struct should not cause infinite loop",
+		plugin: &NilSliceNormalizer{LogLevel: LogLevelWarn},
+		input:  cyclicNodeA,
+		expected: &CyclicStructA{
+			Name:    "A",
+			Friends: make([]string, 0),
+			B: &CyclicStructB{
+				Name:    "B",
+				Secrets: make([]string, 0),
+				A:       cyclicNodeA,
+			},
+		},
+		// We can check for either log message, they will both be present.
+		logShouldContain: `"path":"response.Friends"`,
+	})
+
+	// Run all test cases
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var logBuffer bytes.Buffer
+			// Use a handler that doesn't add the time for more predictable log output.
+			logger := slog.New(slog.NewJSONHandler(&logBuffer, &slog.HandlerOptions{
+				ReplaceAttr: func(groups []string, a slog.Attr) slog.Attr {
+					if a.Key == slog.TimeKey {
+						return slog.Attr{} // Omit the time attribute
+					}
+					return a
+				},
+			}))
+
+			tc.plugin.Mutate(tc.input, logger)
+
+			// 1. Assert data equality
+			if !reflect.DeepEqual(tc.input, tc.expected) {
+				t.Errorf("data mismatch:\ngot:  %#v\nwant: %#v", tc.input, tc.expected)
+			}
+
+			// 2. Assert log content
+			logOutput := logBuffer.String()
+			if tc.logShouldContain != "" && !strings.Contains(logOutput, tc.logShouldContain) {
+				t.Errorf("expected log to contain substring:\n--- want ---\n%s\n--- got ---\n%s", tc.logShouldContain, logOutput)
+			}
+			if tc.logShouldContain == "" && logOutput != "" {
+				t.Errorf("expected no log output, but got: %q", logOutput)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This introduces a new extension point in the framework to allow for post-processing of successful RPC and HTTP responses before they are serialized to JSON. This enables developers to create and register custom "mutator" plugins to transparently modify response data across the API.

The primary motivation is to support advanced data normalization, such as converting `nil` slices to empty arrays (`[]`), without requiring modifications to the core framework or individual method implementations.

Implementation Details:
- A new `jonson.ResponseMutator` interface has been added. It defines a single `Mutate` method.
- `jonson.MethodHandlerOptions` now includes a `ResponseMutators []ResponseMutator` slice, allowing users to register one or more plugins.
- The `HttpRpcHandler`, `HttpMethodHandler`, and `WebsocketHandler` have been updated to iterate over any registered mutators and apply them to the result data just before the final JSON marshaling step.
